### PR TITLE
サイドメニューのアコーディオンメニューをタブに切り替えた

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -64,10 +64,6 @@ header {
   height: 65px
 }
 
-aside{
-  min-width: 288px;
-}
-
 .btn {
   font-weight: normal;
 }

--- a/app/javascript/controllers/spot_list_controller.js
+++ b/app/javascript/controllers/spot_list_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="spot-list"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/spot_list_controller.js
+++ b/app/javascript/controllers/spot_list_controller.js
@@ -1,7 +1,25 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="spot-list"
 export default class extends Controller {
-  connect() {
+  static targets = ["spotListContainer"];
+
+  switchTabContent(event) {
+    // 表示されているタブとコンテンツを消す処理
+    // アクティブ状態だとtabには.tab-active.text-primary.bg-base-100がついている
+    // .tab-activeをもつDOMから上記クラスをremoveさせる
+    // Element: removeAttribute() メソッド
+
+    // コンテンツには特になし。アクティブでないコンテンツに.hiddenがついている
+    // タブから紐づく形でコンテンツを発見させて要素を変えたい
+    // .contents_activeを検討したがTabと紐づかなければ処理に違和感がある
+    // tabにdata-tab-numberでナンバリングする
+    // `.contenttab${Number}`でquerySelectorで取得する
+
+    // クリックしたタブをアクティブにする処理
+    // クリックしたタブに紐づいたコンテンツを表示させる処理
+
+
+    );
   }
 }

--- a/app/javascript/controllers/spot_list_controller.js
+++ b/app/javascript/controllers/spot_list_controller.js
@@ -5,21 +5,25 @@ export default class extends Controller {
   static targets = ["spotListContainer"];
 
   switchTabContent(event) {
-    // 表示されているタブとコンテンツを消す処理
-    // アクティブ状態だとtabには.tab-active.text-primary.bg-base-100がついている
-    // .tab-activeをもつDOMから上記クラスをremoveさせる
-    // Element: removeAttribute() メソッド
+    const activeTab = this.spotListContainerTarget.querySelector(".tab-active");
+    activeTab.classList.remove("tab-active", "bg-base-100");
+    activeTab.classList.add("bg-accent");
+    activeTab.setAttribute("data-action", "click->spot-list#switchTabContent");
 
-    // コンテンツには特になし。アクティブでないコンテンツに.hiddenがついている
-    // タブから紐づく形でコンテンツを発見させて要素を変えたい
-    // .contents_activeを検討したがTabと紐づかなければ処理に違和感がある
-    // tabにdata-tab-numberでナンバリングする
-    // `.contenttab${Number}`でquerySelectorで取得する
+    event.target.classList.add("tab-active", "bg-base-100");
+    event.target.removeAttribute("data-action");
+    const indexActiveTab = Array.from(
+      this.spotListContainerTarget.querySelectorAll(".tab")
+    ).indexOf(activeTab);
+    this.spotListContainerTarget.lastChild.children[
+      indexActiveTab
+    ].classList.add("hidden");
 
-    // クリックしたタブをアクティブにする処理
-    // クリックしたタブに紐づいたコンテンツを表示させる処理
-
-
-    );
+    const indexTargetTab = Array.from(
+      this.spotListContainerTarget.querySelectorAll(".tab")
+    ).indexOf(event.target);
+    this.spotListContainerTarget.lastChild.children[
+      indexTargetTab
+    ].classList.remove("hidden");
   }
 }

--- a/app/javascript/controllers/spots_list_item_controller.js
+++ b/app/javascript/controllers/spots_list_item_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="spots-list"
+// Connects to data-controller="spots-list-item"
 export default class extends Controller {
   static targets = ["item"];
   static outlets = ["map"];

--- a/app/views/home/_aside.html.slim
+++ b/app/views/home/_aside.html.slim
@@ -1,39 +1,33 @@
 = turbo_frame_tag 'side_menu', class: 'flex flex-col h-full' do
-  section#spot_list data-controller="spots-list"
-    .tabs
-      a.tab.tab-lifted.tab-lg.text-xl.tab-active.text-primary.bg-base-100
-        | 最新の投稿
-      a.tab.tab-lifted.tab-lg.text-xl.bg-accent.text-primary
-        | 自分の投稿
-    .bg-base-100.rounded-b-lg.rounded-r-lg.p-4.text-primary class="min-h-[24rem]"
-      = render 'home/aside_latest_spot_list'
-    .bg-base-100.rounded-b-lg.rounded-r-lg.p-4.text-primary.hidden class="min-h-[24rem]"
-      = render 'home/aside_my_spot_list'
+  .how_to_service.mb-5.mt-2
+    button.w-full.btn.bg-base-100.text-primary onclick='how_to_maaks_modal.showModal()'
+      .text-left.text-xl.font-medium.mr-auto
+        | 使い方
+  - if @first_access && !@signed_out
+    dialog id='how_to_maaks_modal' class='modal' open='true'
+      = render 'home/modal_box', how_to_maaks: true
+  - else
+    dialog id='how_to_maaks_modal' class='modal'
+      = render 'home/modal_box', how_to_maaks: true
 
-  section.spot_list.mt-1.mb-5.flex-auto
-    - if user_signed_in?
-      .my_spot_list.mt-5.mb-5
-        .collapse.bg-base-100.text-primary.collapse-arrow
-          input.w-full type='checkbox'
-          .collapse-title.text-xl.font-medium
+    section#spot_list data-controller="spot-list" data-spot-list-target="spotListContainer"
+      - if user_signed_in?
+        .tabs
+          a.tab.tab-lifted.tab-lg.text-xl.tab-active.text-primary.bg-base-100.rounded-none.rounded-t
+            | 最新の投稿
+          a.tab.tab-lifted.tab-lg.text-xl.bg-accent.text-primary.rounded-none.rounded-t data-action="click->spot-list#switchTabContent"
             | 自分の投稿
-          .collapse-content
+        .contents
+          .bg-base-100.rounded-b.rounded-r.p-4.text-primary class="min-h-[24rem]"
+            = render 'home/aside_latest_spot_list'
+          .bg-base-100.rounded-b.rounded-r.p-4.text-primary.hidden class="min-h-[24rem]"
             = render 'home/aside_my_spot_list'
-    .latest_spot_list.mt-5.mb-5
-      .collapse.bg-base-100.text-primary.collapse-arrow
-        input.w-full type='checkbox'
-        .collapse-title.text-xl.font-medium
-          | 最新の投稿
-        .collapse-content
-          = render 'home/aside_latest_spot_list'
-    .how_to_service.mt-5.mb-5
-      button.w-full.btn.bg-base-100.text-primary onclick='how_to_maaks_modal.showModal()'
-        .text-left.text-xl.font-medium.mr-auto
-          | 使い方
-    - if @first_access && !@signed_out
-      dialog id='how_to_maaks_modal' class='modal' open='true'
-        = render 'home/modal_box', how_to_maaks: true
-    - else
-      dialog id='how_to_maaks_modal' class='modal'
-        = render 'home/modal_box', how_to_maaks: true
+      - else
+        .tabs
+          a.tab.tab-lifted.tab-lg.text-xl.tab-active.text-primary.bg-base-100
+            | 最新の投稿
+        .contents
+          .bg-base-100.rounded-b-lg.rounded-r-lg.p-4.text-primary class="min-h-[24rem]"
+            = render 'home/aside_latest_spot_list'
+
   = render 'home/aside_footer'

--- a/app/views/home/_aside.html.slim
+++ b/app/views/home/_aside.html.slim
@@ -1,4 +1,15 @@
 = turbo_frame_tag 'side_menu', class: 'flex flex-col h-full' do
+  section#spot_list data-controller="spots-list"
+    .tabs
+      a.tab.tab-lifted.tab-lg.text-xl.tab-active.text-primary.bg-base-100
+        | 最新の投稿
+      a.tab.tab-lifted.tab-lg.text-xl.bg-accent.text-primary
+        | 自分の投稿
+    .bg-base-100.rounded-b-lg.rounded-r-lg.p-4.text-primary class="min-h-[24rem]"
+      = render 'home/aside_latest_spot_list'
+    .bg-base-100.rounded-b-lg.rounded-r-lg.p-4.text-primary.hidden class="min-h-[24rem]"
+      = render 'home/aside_my_spot_list'
+
   section.spot_list.mt-1.mb-5.flex-auto
     - if user_signed_in?
       .my_spot_list.mt-5.mb-5

--- a/app/views/home/_spot_item.html.slim
+++ b/app/views/home/_spot_item.html.slim
@@ -1,6 +1,6 @@
 = turbo_frame_tag 'spot_item' do
   ul
     - spots.each do |spot|
-      li.my-1.inline-block.w-full.link.link-hover data-controller="spots-list" data-spots-list-target='item' data-spots-list-map-outlet='#map' data-longitude="#{spot.longitude}" data-latitude="#{spot.latitude}" data-action='click->spots-list#jumpToSpot'
+      li.my-1.inline-block.w-full.link.link-hover data-controller="spots-list-item" data-spots-list-item-target='item' data-spots-list-item-map-outlet='#map' data-longitude="#{spot.longitude}" data-latitude="#{spot.latitude}" data-action='click->spots-list-item#jumpToSpot'
         | #{spot.created_at.month}月#{spot.created_at.day}日 #{spot.title}
   == pagy_nav(pagy)

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,7 +1,7 @@
 main.w-full.lg:flex-row-reverse.lg:flex class="h-[calc(100vh-65px)]"
   #map.h-4/6.lg:h-full.lg:basis-9/12 data-controller='map' data-map-target='map' data-map-spot-outlet='.spot_marker' data-action='click->map#createMarker click->map#deleteSpotMenu' data-mapbox-access-token="#{@mapbox_access_token}" data-mapbox-style="#{@mapbox_style}"
 
-  aside.bg-neutral.mr-0.5.p-3.lg:basis-3/12 data-side-menu-map-outlet='#map'
+  aside.bg-neutral.mr-0.5.p-3.lg:basis-3/12 data-side-menu-map-outlet='#map' class="min-w-[20rem]"
     = turbo_frame_tag 'side_menu' do
       = render 'aside'
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,2 +1,2 @@
-Pagy::DEFAULT[:items] = 15
+Pagy::DEFAULT[:items] = 10
 Pagy::DEFAULT[:size]  = [1,2,2,1]


### PR DESCRIPTION
進捗MTGにてアコーディオンメニューがいかにもDaisyUIのパーツありきで選定されたものっぽいとの指摘があり、否めなかったためデザイン相談の上でタブに変更することにした。

HTML、CSSで表示を差し替えて、Stimulusで動作を実装した。
タブをクリックすることでタブに表記のコンテンツに差し替わるようになった。

- #226 