### PR TITLE
登録済みの場合のFlashメッセージを追加

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -40,7 +40,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
     else
       session["devise.#{provider}_data"] = request.env['omniauth.auth'].except(:extra)
-      redirect_to new_user_registration_url
+      redirect_to new_user_registration_url, alert: t('view.this_mail_address_used')
     end
   end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -54,3 +54,4 @@ ja:
     privacy_policy: プライバシーポリシー
     developers_blog: 開発者のブログ
     sign_in_with_google: Googleアカウントでログイン
+    this_mail_address_used: このメールアドレスは登録済みです


### PR DESCRIPTION
OAuthでログインしようとした際に、使用するメールアドレスがMAAKS側で登録済みの際にリダイレクトするがFlashメッセージがなかったため挙動の理由が分かりづらかった。その対応。