### PR TITLE
pathの設定ミスの修正

### DIFF
--- a/app/views/spots/_new_form.html.slim
+++ b/app/views/spots/_new_form.html.slim
@@ -60,6 +60,6 @@
       .flex.flex-col
         p.text-base-100.my-2
           = t 'view.user_registration_is_required_to_register_spot'
-        = link_to t('view.create_user_account'), new_user_registration_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100'
+        = link_to t('view.create_user_account'), new_user_session_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100'
 
   = link_to t('view.cancel'), home_aside_index_path, class: 'my-2 text-base-100 hover:opacity-50 transition-all duration-100 underline'

--- a/app/views/spots/_new_form.html.slim
+++ b/app/views/spots/_new_form.html.slim
@@ -60,6 +60,6 @@
       .flex.flex-col
         p.text-base-100.my-2
           = t 'view.user_registration_is_required_to_register_spot'
-        = link_to t('view.create_user_account'), new_user_session_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100'
+        = link_to t('view.create_user_account'), new_user_session_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100 spot-creating-required-logged-in'
 
   = link_to t('view.cancel'), home_aside_index_path, class: 'my-2 text-base-100 hover:opacity-50 transition-all duration-100 underline'

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -74,6 +74,8 @@ class SpotsTest < ApplicationSystemTestCase
     click_on('スポットを作成する')
 
     assert_text 'スポットの登録にはユーザー登録が必要です'
+    find('.spot-creating-required-logged-in').click
+    assert_text 'ログイン'
   end
 
   test 'error message is displayedcreate when create spot' do


### PR DESCRIPTION
## チケットへのリンク
* https://github.com/users/YukiWatanabe824/projects/2/views/1?pane=issue&itemId=57456525

## やったこと
* 未ログインでスポットを作成しようとする際にユーザーログインを促すボタンを表示していたがその飛び先のpathが誤っていた。その修正
* 上記修正にともなうTestの修正
* i18nのテキストがふさわしくないため、その修正

## やらないこと
なし

## できるようになること（ユーザ目線）
* 該当ボタンから適正にページ遷移できるようになる

## できなくなること（ユーザ目線）
* なし

## 動作確認
* 手動チェックを行い、ローカル環境上で正しくページ遷移することを確認した
* 自動テスト

## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）