### PR TITLE
#new_spot_markerが生成されたら自動でスポット登録画面に遷移するようにする

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -66,3 +66,7 @@ input#spot_longitude {
 input#spot_latitude {
   filter: brightness(0.8)
 }
+
+.spot_marker {
+  z-index: 3;
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -34,17 +34,14 @@ export default class extends Controller {
       .then((response) => response.json())
       .then((spots) => {
         for (const spot of spots) {
-          const el = document.createElement("div");
-          el.id = spot.id;
-          el.className = `spot-${spot.id} spot_marker color_palette solid_icon`;
-          el.setAttribute("data-controller", "spot");
-          el.setAttribute("data-spot-target", "spot");
-          el.setAttribute("data-action", "click->spot#setSpotInfoForSideMenu");
-          new mapboxgl.Marker({
-            element: el,
-          })
-            .setLngLat([spot.longitude, spot.latitude])
-            .addTo(map);
+          const marker = new mapboxgl.Marker({});
+          marker.getElement().id = `${spot.id}`;
+          marker.getElement().classList.add(`spot-${spot.id}`, "spot_marker");
+          marker.getElement().setAttribute("data-controller", "spot");
+          marker.getElement().setAttribute("data-spot-target", "spot");
+          marker.getElement().setAttribute("data-action", "click->spot#setSpotInfoForSideMenu");
+
+          marker.setLngLat([spot.longitude, spot.latitude]).addTo(map);
         }
       });
   }

--- a/app/javascript/controllers/new_spot_marker_controller.js
+++ b/app/javascript/controllers/new_spot_marker_controller.js
@@ -2,21 +2,7 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {
-    document.querySelector("#new_spot_marker").addEventListener("pointerdown", () => {
-      const intervalId = setInterval(changeMenu, 300);
-
-      document.addEventListener(
-        "pointerup",
-        () => {
-          clearInterval(intervalId);
-        },
-        { once: true }
-      );
-    });
-
-    const changeMenu = () => {
-      const url = "spots/new";
-      Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
-    };
+    const url = "spots/new";
+    Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
   }
 }

--- a/app/javascript/controllers/spot_controller.js
+++ b/app/javascript/controllers/spot_controller.js
@@ -3,7 +3,8 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["spot"];
 
-  setSpotInfoForSideMenu() {
+  setSpotInfoForSideMenu(event) {
+    event.stopPropagation()
     const url = `spots/${this.spotTarget.id}`;
     Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
   }

--- a/app/javascript/controllers/spot_controller.js
+++ b/app/javascript/controllers/spot_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ["spot"];
 
   setSpotInfoForSideMenu(event) {
-    event.stopPropagation()
+    event.stopPropagation();
     const url = `spots/${this.spotTarget.id}`;
     Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
   }

--- a/test/system/spots_test.rb
+++ b/test/system/spots_test.rb
@@ -10,7 +10,9 @@ class SpotsTest < ApplicationSystemTestCase
 
   test 'showing spot menu by right click on spot marker' do
     visit_root_closed_modal
-    find('#map').click
+    spot = spots(:one)
+
+    find(".spot-#{spot.id}", visible: false).click(x: 50, y: 50)
     find('#new_spot_marker').right_click
     assert_selector '#spot_menu'
   end
@@ -34,7 +36,9 @@ class SpotsTest < ApplicationSystemTestCase
     sign_in user
     visit_root_closed_modal
 
-    find('#map').click
+    spot = spots(:one)
+
+    find(".spot-#{spot.id}", visible: false).click(x: 50, y: 50)
     find('#new_spot_marker').right_click
     click_on('スポットを作成する')
 
@@ -51,7 +55,9 @@ class SpotsTest < ApplicationSystemTestCase
     sign_in user
     visit_root_closed_modal
 
-    find('#map').click
+    spot = spots(:one)
+
+    find(".spot-#{spot.id}", visible: false).click(x: 50, y: 50)
     find('#new_spot_marker').right_click
     click_on('スポットを作成する')
 
@@ -67,7 +73,9 @@ class SpotsTest < ApplicationSystemTestCase
     visit_root_closed_modal
     assert_selector '#map'
 
-    find('#map').click
+    spot = spots(:one)
+
+    find(".spot-#{spot.id}", visible: false).click(x: 50, y: 50)
 
     assert_selector '#new_spot_marker'
     find('#new_spot_marker').right_click
@@ -84,7 +92,9 @@ class SpotsTest < ApplicationSystemTestCase
     visit_root_closed_modal
     assert_selector '#map'
 
-    find('#map').click
+    spot = spots(:one)
+
+    find(".spot-#{spot.id}", visible: false).click(x: 50, y: 50)
 
     assert_selector '#new_spot_marker'
     find('#new_spot_marker').right_click


### PR DESCRIPTION
## チケットへのリンク
* https://github.com/users/YukiWatanabe824/projects/2/views/1?pane=issue&itemId=57456481

## やったこと
* 新規Markerがマップ上に出力されたら自動でスポット登録画面に遷移するようにした。
* 上記の状態では既存スポットの詳細画面への遷移と競合し、かき消されるため、DBから出力する登録済みの事故スポットの出力処理を修正。表示方法を変更し、新規Markerと分離して処理が発生するようにした。
* 上記修正にともなうTestの修正

## やらないこと
なし

## できるようになること（ユーザ目線）
* マップ上に新規Markerを立てた段階でスポット登録画面に遷移するようになった

## できなくなること（ユーザ目線）
* なし

## 動作確認
* 手動チェックを行い、ローカル環境上で正しくページ遷移することを確認した
* 自動テスト

## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）