### PR TITLE
スポット登録フォームを表示する要素を画面外からスライドイン-アウトするようにした

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -70,3 +70,18 @@ input#spot_latitude {
 .spot_marker {
   z-index: 3;
 }
+
+.aside_for_reg {
+  display: block;
+  position: absolute;
+  left: 0;
+  translate: -100%;
+  transition: 0.2s ease-in-out;
+  z-index: 3;
+  width: 26vw;
+
+}
+
+.display {
+  translate: 0%;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -79,11 +79,14 @@ input#spot_latitude {
     translate: -100%;
     transition: 0.2s ease-in-out;
     z-index: 3;
-    width: 26vw;
+    width: 28vw;
+    overflow: auto;
+    height: calc(100vh - 65px);
   }
 
   .display {
     translate: 0%;
+    padding: 24px;
   }
 }
 
@@ -98,8 +101,8 @@ input#spot_latitude {
   }
 
   .display {
-    height: 640px;
-    transform: translateY(-120%);
+    height: 60rem;
+    transform: translateY(-90%);
     padding: 36px;
   }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -71,17 +71,35 @@ input#spot_latitude {
   z-index: 3;
 }
 
-.aside_for_reg {
-  display: block;
-  position: absolute;
-  left: 0;
-  translate: -100%;
-  transition: 0.2s ease-in-out;
-  z-index: 3;
-  width: 26vw;
+@media (min-width: 1024px) {
+  .aside_for_reg {
+    display: block;
+    position: absolute;
+    left: 0;
+    translate: -100%;
+    transition: 0.2s ease-in-out;
+    z-index: 3;
+    width: 26vw;
+  }
 
+  .display {
+    translate: 0%;
+  }
 }
 
-.display {
-  translate: 0%;
+@media (max-width: 1023px){
+  .aside_for_reg {
+    position: relative;
+    z-index: 3;
+    height: 0;
+    transform: translateY(100%);
+    transition: transform 0.25s, height 0.25s;
+    overflow: hidden;
+  }
+
+  .display {
+    height: 640px;
+    transform: translateY(-120%);
+    padding: 36px;
+  }
 }

--- a/app/javascript/controllers/new_spot_marker_controller.js
+++ b/app/javascript/controllers/new_spot_marker_controller.js
@@ -4,5 +4,11 @@ export default class extends Controller {
   connect() {
     const url = "spots/new";
     Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
+    this.displayForRegWindow()
+  }
+
+  displayForRegWindow(){
+    const el = document.querySelector(".aside_for_reg")
+    el.classList.add("display")
   }
 }

--- a/app/javascript/controllers/new_spot_marker_controller.js
+++ b/app/javascript/controllers/new_spot_marker_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   connect() {
     const url = "spots/new";
-    Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
+    Turbo.visit(url, { frame: "spot_regist_window" }); //eslint-disable-line
     this.displayForRegWindow()
   }
 

--- a/app/javascript/controllers/new_spot_marker_controller.js
+++ b/app/javascript/controllers/new_spot_marker_controller.js
@@ -4,11 +4,11 @@ export default class extends Controller {
   connect() {
     const url = "spots/new";
     Turbo.visit(url, { frame: "spot_regist_window" }); //eslint-disable-line
-    this.displayForRegWindow()
+    this.displayForRegWindow();
   }
 
-  displayForRegWindow(){
-    const el = document.querySelector(".aside_for_reg")
-    el.classList.add("display")
+  displayForRegWindow() {
+    const el = document.querySelector(".aside_for_reg");
+    el.classList.add("display");
   }
 }

--- a/app/javascript/controllers/showing_spot_menu_controller.js
+++ b/app/javascript/controllers/showing_spot_menu_controller.js
@@ -8,6 +8,11 @@ export default class extends Controller {
   connect() {
     const spotObject = this.SpotDetailPanelTarget.dataset;
     this.addSpot(spotObject);
+    this.regWindowSlideOut();
+  }
+
+  regWindowSlideOut() {
+    document.querySelector(".aside_for_reg").classList.remove("display");
   }
 
   addSpot(spot) {

--- a/app/javascript/controllers/side_menu_for_register_new_spot_controller.js
+++ b/app/javascript/controllers/side_menu_for_register_new_spot_controller.js
@@ -8,6 +8,10 @@ export default class extends Controller {
     this.fillCoordinatesForField();
   }
 
+  slideOut() {
+    document.querySelector(".aside_for_reg").classList.remove("display");
+  }
+
   removeMenu() {
     if (document.querySelector("#spot_menu")) {
       document.querySelector("#spot_menu").remove();

--- a/app/javascript/controllers/spot_controller.js
+++ b/app/javascript/controllers/spot_controller.js
@@ -7,12 +7,12 @@ export default class extends Controller {
     event.stopPropagation();
     const url = `spots/${this.spotTarget.id}`;
     Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
-    this.hiddenForRegWindow()
+    this.hiddenForRegWindow();
   }
 
-  hiddenForRegWindow(){
-    const el = document.querySelector(".aside_for_reg")
-    el.classList.remove("display")
+  hiddenForRegWindow() {
+    const el = document.querySelector(".aside_for_reg");
+    el.classList.remove("display");
   }
 
   showSpotMenu(e) {

--- a/app/javascript/controllers/spot_controller.js
+++ b/app/javascript/controllers/spot_controller.js
@@ -7,6 +7,12 @@ export default class extends Controller {
     event.stopPropagation();
     const url = `spots/${this.spotTarget.id}`;
     Turbo.visit(url, { frame: "side_menu" }); //eslint-disable-line
+    this.hiddenForRegWindow()
+  }
+
+  hiddenForRegWindow(){
+    const el = document.querySelector(".aside_for_reg")
+    el.classList.remove("display")
   }
 
   showSpotMenu(e) {

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -8,4 +8,5 @@ main.w-full.mx-auto.lg:flex-row-reverse.lg:flex class="h-[calc(100vh-65px)] max-
     = turbo_frame_tag 'side_menu' do
       = render partial: 'aside', locals: { signed_out: @signed_out, spots: @spots, spots_pagy: @spots_pagy, my_spots_pagy: @my_spots_pagy, my_spots: @my_spots }
 
-  aside.aside_for_reg.bg-accent.mr-0.5.w-full.lg:h-full data-side-menu-map-outlet='#map' class="min-w-[20rem]"
+  aside.aside_for_reg.bg-primary.mr-0.5.w-full.lg:h-full data-side-menu-map-outlet='#map' class="min-w-[20rem]"
+    = turbo_frame_tag 'spot_regist_window' do

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -4,8 +4,8 @@ main.w-full.mx-auto.lg:flex-row-reverse.lg:flex class="h-[calc(100vh-65px)] max-
 
   #map.bg-white.h-4/6.lg:h-full.lg:basis-9/12 data-controller='map' data-map-target='map' data-map-spot-outlet='.spot_marker' data-action='click->map#createNewSpotMarker click->map#deleteSpotMenu' data-mapbox-access-token="#{@mapbox_access_token}" data-mapbox-style="#{@mapbox_style}"
 
-  aside.bg-neutral.mr-0.5.p-3.lg:basis-3/12 data-side-menu-map-outlet='#map' class="min-w-[20rem]"
+  aside.bg-neutral.mr-0.5.p-3.lg:basis-3/12.lg:h-full data-side-menu-map-outlet='#map' class="min-w-[20rem] h-[40rem]"
     = turbo_frame_tag 'side_menu' do
       = render partial: 'aside', locals: { signed_out: @signed_out, spots: @spots, spots_pagy: @spots_pagy, my_spots_pagy: @my_spots_pagy, my_spots: @my_spots }
 
-  aside.aside_for_reg.bg-secondary.mr-0.5.p-3.lg:h-full data-side-menu-map-outlet='#map' class="min-w-[20rem]"
+  aside.aside_for_reg.bg-accent.mr-0.5.w-full.lg:h-full data-side-menu-map-outlet='#map' class="min-w-[20rem]"

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,8 +1,11 @@
 = content_for(:title, t('title.main'))
 
 main.w-full.mx-auto.lg:flex-row-reverse.lg:flex class="h-[calc(100vh-65px)] max-w-[1980px]"
+
   #map.bg-white.h-4/6.lg:h-full.lg:basis-9/12 data-controller='map' data-map-target='map' data-map-spot-outlet='.spot_marker' data-action='click->map#createNewSpotMarker click->map#deleteSpotMenu' data-mapbox-access-token="#{@mapbox_access_token}" data-mapbox-style="#{@mapbox_style}"
 
   aside.bg-neutral.mr-0.5.p-3.lg:basis-3/12 data-side-menu-map-outlet='#map' class="min-w-[20rem]"
     = turbo_frame_tag 'side_menu' do
       = render partial: 'aside', locals: { signed_out: @signed_out, spots: @spots, spots_pagy: @spots_pagy, my_spots_pagy: @my_spots_pagy, my_spots: @my_spots }
+
+  aside.aside_for_reg.bg-secondary.mr-0.5.p-3.lg:h-full data-side-menu-map-outlet='#map' class="min-w-[20rem]"

--- a/app/views/spots/_new_form.html.slim
+++ b/app/views/spots/_new_form.html.slim
@@ -1,4 +1,4 @@
-= turbo_frame_tag 'side_menu' do
+= turbo_frame_tag 'spot_regist_window' do
   div data-controller="side-menu-for-register-new-spot" data-side-menu-for-register-new-spot-map-outlet='#map'
     h2.my-2.text-xl.font-bold.text-base-100
       = t 'view.create_spot'
@@ -60,6 +60,6 @@
       .flex.flex-col
         p.text-base-100.my-2
           = t 'view.user_registration_is_required_to_register_spot'
-        = link_to t('view.create_user_account'), new_user_session_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100 spot-creating-required-logged-in'
+        = link_to t('view.create_user_account'), new_user_session_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100 spot-creating-required-logged-in max-w-52'
 
-  = link_to t('view.cancel'), home_aside_index_path, class: 'my-2 text-base-100 hover:opacity-50 transition-all duration-100 underline'
+    = link_to t('view.cancel'), home_aside_index_path, class: 'my-2 text-base-100 hover:opacity-50 transition-all duration-100 underline'

--- a/app/views/spots/_new_form.html.slim
+++ b/app/views/spots/_new_form.html.slim
@@ -62,4 +62,5 @@
           = t 'view.user_registration_is_required_to_register_spot'
         = link_to t('view.create_user_account'), new_user_session_path, data: { turbo: false }, class: 'btn bg-base-100 text-primary my-2 hover:opacity-50 transition-all duration-100 spot-creating-required-logged-in max-w-52'
 
-    = link_to t('view.cancel'), home_aside_index_path, class: 'my-2 text-base-100 hover:opacity-50 transition-all duration-100 underline'
+    p.my-2.text-base-100.hover:opacity-50.transition-all.duration-100.underline.link data-action='click->side-menu-for-register-new-spot#slideOut'
+      = t('view.cancel')


### PR DESCRIPTION
## Issue
* https://github.com/users/YukiWatanabe824/projects/2/views/1?pane=issue&itemId=57456505

## 概要
モバイルユーザーがスポット登録画面を表示させた際に、「スッ…」と静かに登録画面が表示されてしまうので気づきづらい状態だった。
これはユーザーのサービス利用フロー上、重大な欠点と思われる。

これを解消するためにスポット登録画面を表示させる際に画面外から要素をスライドインさせることで表示されたことが視覚的にわかりやすくすることにした。

## 変更確認方法
mobile / PC共にマップ上をタップorクリックすることで確認できる

![画面収録 2024-03-27 14 59 06](https://github.com/YukiWatanabe824/MAAKS/assets/69577164/315f4524-90d9-4b6d-88ad-cf382fc42a1c)

## やらないこと
なし

## できるようになること（ユーザ目線）
* スポット登録画面がスライドインで画面上に表示されるようになる

## できなくなること（ユーザ目線）
* 旧版の表示方法は廃止する

## 動作確認
* 手動チェックを行い、ローカル環境上で正しくページ遷移することを確認した
* 自動テスト